### PR TITLE
EventStreamParser: Fixed removal of first space within value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,10 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.2'
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
-    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.1'
+    classpath 'com.android.tools.build:gradle:1.+'
+    classpath 'org.codehaus.groovy:groovy-backports-compat23:2.3.5'
+    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
   }
 }
 

--- a/eventsource/src/main/java/com/tylerjroach/eventsource/impl/EventStreamParser.java
+++ b/eventsource/src/main/java/com/tylerjroach/eventsource/impl/EventStreamParser.java
@@ -46,7 +46,10 @@ public class EventStreamParser {
       }
     } else if ((colonIndex = line.indexOf(":")) != -1) {
       String field = line.substring(0, colonIndex);
-      String value = line.substring(colonIndex + 1).replaceFirst(" ", EMPTY_STRING);
+      String value = line.substring(colonIndex + 1);
+      if (value.charAt(0) == ' '){
+          value = value.substring(1);
+      }
       processField(field, value);
     } else {
       processField(line.trim(),


### PR DESCRIPTION
Instead of using replaceFirst to remove the first space withing the sting, we now explicitly check the first character of the string.
This ensures that no whitespace inside the value gets removed (e.g. "ABC DEF" => "ABCDEF").

Fixes #7
